### PR TITLE
setup: added numpy restriction to maintain python 2.7 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ setup(
    author='Martin Denk https://orcid.org/0000-0002-0204-3608',
    url='https://github.com/DMST1990/ToOptix',
    packages=['ToOptix', 'ToOptix.FEMPy', 'ToOptix.FEMPy.Geometry'],  
-   install_requires=['numpy'], #external packages as dependencies alternative --> Trimesh and Mayavi if true
+   install_requires=['numpy==1.16.3']  # maintain Python 2.7 compatilibity 
+   #external packages as dependencies alternative --> Trimesh and Mayavi if true
    )
 
 


### PR DESCRIPTION
* I changed setup.py slightly to maintain Python 2.7 compatibility. This could be changed later.
* The integration of the core package worked perfect for FreeCAD 0.18